### PR TITLE
Create mapToNextCatch Flow extension

### DIFF
--- a/src/main/kotlin/hu/akarnokd/kotlin/flow/FlowExtensions.kt
+++ b/src/main/kotlin/hu/akarnokd/kotlin/flow/FlowExtensions.kt
@@ -158,6 +158,19 @@ fun <T> Flow<T>.toList() : Flow<List<T>> {
     }
 }
 
+/***
+ * Enable [catch] multiple times after it encounters an error.
+ *
+ * flow {
+ *    ...
+ * }.mapToNextCatch { t1 -> Throwable2(...) }
+ * .mapToNextCatch { t2 -> Throwable3(...) }
+ * .catch { t3 -> ... }
+ */
+@ExperimentalCoroutinesApi
+fun <T> Flow<T>.mapToNextCatch(errorMap: (Throwable) -> Throwable): Flow<T> =
+        catch { throw errorMap(it) }
+
 // -----------------------------------------------------------------------------------------
 // Parallel Extensions
 // -----------------------------------------------------------------------------------------

--- a/src/test/kotlin/hu/akarnokd/kotlin/flow/FlowErrorExtensionTest.kt
+++ b/src/test/kotlin/hu/akarnokd/kotlin/flow/FlowErrorExtensionTest.kt
@@ -1,0 +1,46 @@
+package hu.akarnokd.kotlin.flow
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.IllegalStateException
+import kotlin.test.assertNotNull
+
+@FlowPreview
+@ExperimentalCoroutinesApi
+class FlowErrorExtensionTest {
+
+    @Test
+    fun flowShouldMapToNextCatchMultipleTimes() = runBlocking {
+
+        var exception: Throwable? = null
+
+        flow {
+            repeat(3) {
+                if (it == 2) {
+                    throw IllegalArgumentException("error on emit")
+                }
+                emit(it)
+            }
+        }.mapToNextCatch {
+            IllegalStateException("received ${it.message}")
+        }.mapToNextCatch {
+            MyFlowException("New throwable map ${it.message}")
+        }.catch {
+            exception = it
+        }.collect {}
+
+        assertNotNull(exception)
+        assertTrue(exception is MyFlowException)
+        assertEquals(exception?.message, "New throwable map received error on emit")
+    }
+
+    class MyFlowException(msg: String) : Throwable(msg)
+
+}


### PR DESCRIPTION
Usage example:
```kotlin
flow {
    // throw SocketTimeoutException on emit
}.mapToNextCatch { t1 ->
   // map SocketTimeoutException to NetworkConnectionException
   NetworkConnectionException(...)
}.catch { t2 ->
   // receive NetworkConnectionException
}
```